### PR TITLE
Handle overwrites by file moves and restart on error

### DIFF
--- a/ltk/watch.py
+++ b/ltk/watch.py
@@ -107,7 +107,7 @@ class WatchAction(Action):
         if not event.is_directory and in_db:
             try:
                 # check that document is added in TMS before updating
-                if self.check_remote_doc_exist(fn):
+                if self.check_remote_doc_exist(fn) and self.doc_manager.is_doc_modified(fn, self.path):
                     # logger.info('Detected local content modified: {0}'.format(fn))
                     # self.update_document_action(os.path.join(self.path, fn))
                     # logger.info('Updating remote content: {0}'.format(fn))

--- a/ltk/watch.py
+++ b/ltk/watch.py
@@ -75,6 +75,7 @@ class WatchAction(Action):
         self.handler = WatchHandler()
         self.handler.on_modified = self._on_modified
         self.handler.on_created = self._on_created
+        self.handler.on_moved = self._on_moved
         self.watch_queue = []  # not much slower than deque unless expecting 100+ items
         self.locale_delimiter = None
         self.ignore_ext = []  # file types to ignore as specified by the user

--- a/ltk/watch.py
+++ b/ltk/watch.py
@@ -118,6 +118,12 @@ class WatchAction(Action):
             except ConnectionError:
                 print("Could not connect to remote.")
                 restart()
+            except JSONDecodeError:
+                print(sys.exc_info()[1])
+                restart()
+            except ValueError:
+                print(sys.exc_info()[1])
+                restart()
             # except:
             #     print(sys.exc_info()[1])
             #     print("Unable to update document.")
@@ -158,6 +164,12 @@ class WatchAction(Action):
                 self.observer.stop()
             except ConnectionError:
                 print("Could not connect to remote.")
+                restart()
+            except JSONDecodeError:
+                print(sys.exc_info()[1])
+                restart()
+            except ValueError:
+                print(sys.exc_info()[1])
                 restart()
             # except:
             #     print(sys.exc_info()[1])

--- a/ltk/watchhandler.py
+++ b/ltk/watchhandler.py
@@ -14,6 +14,9 @@ class WatchHandler(FileSystemEventHandler):
     def on_created(self, event):
         self.process(event)
 
+    def on_moved(self, event):
+        self.process(event)
+
     # on modified
     # on moved
     # on deleted

--- a/tests/test_actions/__init__.py
+++ b/tests/test_actions/__init__.py
@@ -46,4 +46,4 @@ def cleanup():
     try:
         shutil.rmtree(conf_path)
     except OSError:
-        print 'OSError in cleanup'
+        print ('OSError in cleanup')

--- a/tests/test_actions/test_init.py
+++ b/tests/test_actions/test_init.py
@@ -6,6 +6,7 @@ class TestInitAction(unittest.TestCase):
 
     def test_uninitialized(self):
         # todo create dir outside so folder not initialized
+        os.chdir('/')
         self.assertRaises(exceptions.UninitializedError, actions.Action, os.getcwd())
 
     def test_init_host(self):


### PR DESCRIPTION
Lines 127-130 and 174-177 are commented out since it means catching all other exceptions, though I think it would be better to print the error and restart for any type of exception, or instead just stop the watch. Currently after an uncaught exception the watch looks like it continues, but it no longer works.
It also looks like the code should be refactored to put the similar parts of _on_modified and _on_created into the same function.